### PR TITLE
feat: add self-hosted deployment support with Docker and Traefik

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,18 @@
+# Keeps the Docker build context (repo root) small and prevents local-only
+# files — especially anything under web/ that isn't checked in, like a
+# local .env — from being sent to the daemon or copied into a build stage.
+
+.git
+.github
+
+docs
+samples
+*.md
+
+web/node_modules
+web/dist
+web/coverage
+web/.env
+web/.env.*
+web/.husky
+web/.vscode

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,9 @@ updates:
       timezone: "UTC"
     open-pull-requests-limit: 10
     reviewers:
-      - "matthall00"
+      - "slightlyprivate"
     assignees:
-      - "matthall00"
+      - "slightlyprivate"
     commit-message:
       prefix: "deps"
       prefix-development: "deps-dev"
@@ -45,9 +45,9 @@ updates:
       timezone: "UTC"
     open-pull-requests-limit: 5
     reviewers:
-      - "matthall00"
+      - "slightlyprivate"
     assignees:
-      - "matthall00"
+      - "slightlyprivate"
     commit-message:
       prefix: "ci"
       include: "scope"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,72 @@
+name: Docker Build and Publish
+
+on:
+  push:
+    branches: [ main ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: slightlyprivate/spread-your-sheets-web
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+      - name: Install dependencies
+        run: |
+          cd web
+          npm ci
+      - name: Lint
+        run: |
+          cd web
+          npm run lint
+      - name: Test
+        run: |
+          cd web
+          npm run test -- --run
+      - name: Build
+        run: |
+          cd web
+          npm run build
+
+  publish:
+    needs: quality
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set image tag
+        id: vars
+        run: echo "sha_tag=main-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deploy/Dockerfile.prod
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.vars.outputs.sha_tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -124,7 +124,7 @@ This section reflects a **planned, optional** future direction. The current rela
 - [x] `npm run build` verified (from `web/`)
 - [ ] Static frontend build deployed to slightly-server behind Cloudflare Tunnel
 - [ ] Live demo link added to README
-- [ ] Deployment artifacts (Docker/Caddy/Nginx, health check) added to repo
+- [x] Deployment artifacts (Docker/nginx, health check) added to repo
 - [ ] Versioned release tag + CHANGELOG entry
 
 ## 🧾 Documentation

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-matthall00@github.com.
+<25968932+slightlyprivate@users.noreply.github.com>.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/PRD.md
+++ b/PRD.md
@@ -133,7 +133,7 @@ No backend is implemented, and no backend scaffolding exists in this repository 
 
 Current relaunch direction: frontend-only, browser-local processing, no backend dependency.
 
-The intended relaunch deployment is a static frontend build served from slightly-server behind Cloudflare Tunnel, at `spreadyoursheets.slightlyprivate.com`. Concrete deployment artifacts (Docker/Caddy/Nginx config, health check convention) do not yet exist in this repository — see the roadmap in [docs/relaunch/CODEBASE_AUDIT.md](docs/relaunch/CODEBASE_AUDIT.md).
+The relaunch deployment is a static frontend build packaged into a Docker/nginx image and served from slightly-server behind a shared Traefik proxy and Cloudflare Tunnel, at `spreadyoursheets.slightlyprivate.com`. Deployment artifacts (Dockerfile, nginx config, compose template, health check) exist in this repository — see [docs/deployment/self-hosted.md](docs/deployment/self-hosted.md). The stack has not yet been deployed live on slightly-server.
 
 ## 12. Roadmap phases
 
@@ -143,7 +143,7 @@ The intended relaunch deployment is a static frontend build served from slightly
 | 2 | Rebrand UI/copy to Spread Your Sheets | Done |
 | 3 | Scope cleanup: remove dead files/backend scaffolding, fix placeholder actions and untruthful settings | Done |
 | 4 | Distinctive UI/UX redesign pass | Done |
-| 5 | Self-host deployment artifacts for slightly-server + Cloudflare Tunnel | Not started |
+| 5 | Self-host deployment artifacts for slightly-server + Cloudflare Tunnel | Artifacts done; live deployment pending |
 | 6 | Final QA, docs, and public relaunch | Not started |
 
 ## 13. Conclusion

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ Not implemented yet — tracked as relaunch roadmap items, not current features:
 - Processed data export (CSV/JSON)
 - Additional chart export formats (for example SVG)
 - Optional backend processing for larger files (no backend scaffolding exists in this repo today — it would be built fresh from a real requirement)
-- Self-host deployment packaging (Docker/Caddy/Nginx config) for the target infrastructure
 - Natural-language data summaries, saved dashboards, and other longer-term ideas (see Roadmap below)
 
 ## Tech stack
@@ -155,7 +154,10 @@ Try these datasets from [`samples/`](samples):
 
 **Current relaunch direction:** frontend-only, browser-local processing. No backend is required or currently used.
 
-**Planned deployment:** The intended relaunch deployment is a static frontend build served from slightly-server behind Cloudflare Tunnel, at `spreadyoursheets.slightlyprivate.com`. Operational artifacts for this (server config, tunnel routing) are not yet part of this repository — see [docs/architecture.md](docs/architecture.md) for status.
+Production deployment is a self-hosted static build (nginx, pre-built GHCR
+Docker image) served from slightly-server behind a shared Traefik and
+Cloudflare Tunnel, at `spreadyoursheets.slightlyprivate.com`. For self-hosting
+instructions, see [docs/deployment/self-hosted.md](docs/deployment/self-hosted.md).
 
 For local production builds:
 

--- a/deploy/Dockerfile.prod
+++ b/deploy/Dockerfile.prod
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1
+
+# Build context is the repository root, e.g.:
+#   docker build -f deploy/Dockerfile.prod -t spread-your-sheets-web:local .
+
+FROM node:22-alpine AS build
+WORKDIR /app
+
+COPY web/package.json web/package-lock.json ./
+RUN npm ci
+
+COPY web/ ./
+RUN npm run build
+
+FROM nginx:alpine AS runtime
+
+COPY deploy/nginx/default.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+
+EXPOSE 80

--- a/deploy/nginx/default.conf
+++ b/deploy/nginx/default.conf
@@ -1,0 +1,37 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    server_tokens off;
+
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript image/svg+xml;
+
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+    # Simple liveness check for container/orchestrator health checks.
+    location = /health {
+        default_type text/plain;
+        return 200 "ok";
+    }
+
+    # Hashed build assets are safe to cache aggressively.
+    location /assets/ {
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+        try_files $uri =404;
+    }
+
+    # index.html must always be revalidated so SPA deploys are picked up.
+    location = /index.html {
+        add_header Cache-Control "no-cache" always;
+    }
+
+    # SPA fallback: any unmatched route serves index.html.
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/deploy/slightly-server/.env.example
+++ b/deploy/slightly-server/.env.example
@@ -1,0 +1,10 @@
+# Copy this file to .env in the same directory and adjust as needed.
+
+# Public hostname Traefik routes to this service. Must exactly match the
+# hostname configured in the Cloudflare Tunnel (public hostname -> http://traefik:80).
+APP_HOST=spreadyoursheets.slightlyprivate.com
+
+# GHCR image tag to deploy. Use "latest" to track main, or pin a specific
+# build with "main-<short-sha>" (see the docker-build workflow run for the
+# short sha) for reproducible deploys and easy rollback.
+IMAGE_TAG=latest

--- a/deploy/slightly-server/docker-compose.yml
+++ b/deploy/slightly-server/docker-compose.yml
@@ -1,0 +1,20 @@
+# Compose stack for running Spread Your Sheets on slightly-server behind the
+# shared Traefik reverse proxy. See docs/deployment/self-hosted.md for setup.
+
+services:
+  web:
+    image: ghcr.io/slightlyprivate/spread-your-sheets-web:${IMAGE_TAG:-latest}
+    restart: unless-stopped
+    networks:
+      - traefik-proxy
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=traefik-proxy"
+      - "traefik.http.routers.spread-your-sheets.rule=Host(`${APP_HOST}`)"
+      - "traefik.http.routers.spread-your-sheets.entrypoints=web"
+      - "traefik.http.routers.spread-your-sheets.service=spread-your-sheets-web"
+      - "traefik.http.services.spread-your-sheets-web.loadbalancer.server.port=80"
+
+networks:
+  traefik-proxy:
+    external: true

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -253,10 +253,10 @@ Do not describe this as "comprehensive testing" or claim a specific coverage per
 
 **Current state:** frontend-only static build (`npm run build` from `web/`), no backend dependency, verified working locally and in CI.
 
-**Planned relaunch deployment:** The intended relaunch deployment is a static frontend build served from slightly-server behind Cloudflare Tunnel, at `spreadyoursheets.slightlyprivate.com`. This repository does not yet contain the operational artifacts for that (no Dockerfile, reverse-proxy config, systemd unit, or health-check convention) — those are tracked as a later relaunch phase, not part of this documentation pass.
+**Self-host deployment:** The relaunch deployment is a static frontend build packaged into a pre-built nginx Docker image, published to GHCR, and run on slightly-server behind a shared Traefik reverse proxy and a manually configured Cloudflare Tunnel, at `spreadyoursheets.slightlyprivate.com`. See [docs/deployment/self-hosted.md](deployment/self-hosted.md) for full setup, update, and rollback instructions.
 
 ```text
-Git push → CI: lint → build → test  (implemented)
-Local/CI build → web/dist           (implemented)
-web/dist → static server → Cloudflare Tunnel → spreadyoursheets.slightlyprivate.com  (planned, not yet wired up)
+Git push to main → CI: lint → build → test → Docker build → push to GHCR   (implemented)
+GHCR image → docker compose pull/up on slightly-server                     (implemented, manual trigger)
+slightly-server (Traefik) → Cloudflare Tunnel → spreadyoursheets.slightlyprivate.com  (Tunnel routing configured manually, outside this repo)
 ```

--- a/docs/deployment/self-hosted.md
+++ b/docs/deployment/self-hosted.md
@@ -1,0 +1,170 @@
+# Self-hosted deployment (slightly-server)
+
+Spread Your Sheets is a frontend-only app: everything runs client-side in the
+browser, and there is no backend, database, or persistent storage. Production
+deployment is a single pre-built nginx image serving the static build,
+fronted by a reverse proxy that already runs on the target host.
+
+## Host assumptions
+
+- Target host is **slightly-server**, running Docker and Docker Compose.
+- A shared **Traefik** instance already runs on that host, attached to an
+  external Docker network named `traefik-proxy`, with an entrypoint named
+  `web`.
+- A **Cloudflare Tunnel** is already configured outside this repo, routing
+  `spreadyoursheets.slightlyprivate.com` to `http://traefik:80`. This stack
+  does not run its own `cloudflared` container.
+- No database, queue, scheduler, migrations, or persistent app storage are
+  needed by this app.
+
+## Image strategy
+
+- The image is built from [`deploy/Dockerfile.prod`](../../deploy/Dockerfile.prod):
+  a Node 22 stage runs `npm ci` and `vite build` in `web/`, and the resulting
+  `web/dist` is copied into an `nginx:alpine` runtime stage. The final image
+  contains no source files, no `node_modules`, and no backend runtime.
+- Images are built and published automatically by
+  [`.github/workflows/docker-build.yml`](../../.github/workflows/docker-build.yml)
+  on every push to `main`, and pushed to:
+
+  ```text
+  ghcr.io/slightlyprivate/spread-your-sheets-web:latest
+  ghcr.io/slightlyprivate/spread-your-sheets-web:main-<short-sha>
+  ```
+
+  Pull requests do not publish images.
+
+## Directory layout
+
+On the host, the stack lives under:
+
+```text
+/srv/stacks/spread-your-sheets/
+  docker-compose.yml
+  .env
+```
+
+`docker-compose.yml` and `.env.example` are tracked in this repo under
+[`deploy/slightly-server/`](../../deploy/slightly-server/) and copied to the
+host as-is; `.env` itself is host-local and not committed anywhere.
+
+## Initial setup
+
+```bash
+mkdir -p /srv/stacks/spread-your-sheets
+cd /srv/stacks/spread-your-sheets
+
+# copy docker-compose.yml and .env.example from repo deploy/slightly-server/
+cp .env.example .env
+# edit .env if needed (APP_HOST, IMAGE_TAG)
+
+docker compose pull
+docker compose up -d
+
+curl https://spreadyoursheets.slightlyprivate.com/health
+```
+
+The `traefik-proxy` network must already exist on the host (it's created and
+owned by the shared Traefik stack, not by this one).
+
+## Updating
+
+```bash
+cd /srv/stacks/spread-your-sheets
+docker compose pull
+docker compose up -d
+docker image prune -f
+curl https://spreadyoursheets.slightlyprivate.com/health
+```
+
+With `IMAGE_TAG=latest` (the default), this always deploys the most recent
+`main` build.
+
+## Rollback
+
+Pin `.env` to a previous build's short-sha tag, then redeploy:
+
+```bash
+# in .env:
+# IMAGE_TAG=main-<previous-short-sha>
+
+docker compose pull
+docker compose up -d
+curl https://spreadyoursheets.slightlyprivate.com/health
+```
+
+Short-sha tags for past builds are visible in the GHCR package's version
+history, or by finding the corresponding commit on `main`.
+
+## Health check
+
+The nginx image exposes `GET /health`, returning HTTP 200 with the plain-text
+body `ok`. Use it for manual verification, uptime checks, or container
+health checks.
+
+## Reverse proxy / Traefik labels
+
+The `web` service is not published on a host port; Traefik reaches it over
+the `traefik-proxy` network using these labels (already set in
+[`docker-compose.yml`](../../deploy/slightly-server/docker-compose.yml)):
+
+```yaml
+labels:
+  - "traefik.enable=true"
+  - "traefik.docker.network=traefik-proxy"
+  - "traefik.http.routers.spread-your-sheets.rule=Host(`${APP_HOST}`)"
+  - "traefik.http.routers.spread-your-sheets.entrypoints=web"
+  - "traefik.http.routers.spread-your-sheets.service=spread-your-sheets-web"
+  - "traefik.http.services.spread-your-sheets-web.loadbalancer.server.port=80"
+```
+
+`APP_HOST` comes from `.env` and must match the public hostname configured in
+the Cloudflare Tunnel.
+
+## Cloudflare Tunnel note
+
+The tunnel is configured manually, outside this repo, with a public hostname
+rule:
+
+```text
+spreadyoursheets.slightlyprivate.com -> http://traefik:80
+```
+
+This repo does not manage or run `cloudflared`; it only assumes that rule
+already exists and points at the shared Traefik entrypoint.
+
+## Troubleshooting
+
+- **Image pull fails / unauthorized** — confirm the GHCR package
+  `spread-your-sheets-web` is set to public visibility (packages can default
+  to private on first publish even from a public repo; this may need to be
+  changed once manually on GitHub after the first workflow run).
+- **`curl` to the public hostname fails or times out** — check `APP_HOST` in
+  `.env` matches the Cloudflare Tunnel public hostname exactly (including
+  no trailing slash/protocol).
+- **Traefik never picks up the service** — verify the external `traefik-proxy`
+  network exists (`docker network ls`) and that the `web` container is
+  attached to it (`docker inspect` or `docker compose ps`).
+- **Cloudflare reports the hostname but the app doesn't load** — confirm the
+  tunnel's public hostname rule points at `http://traefik:80`, and that
+  Traefik's `web` entrypoint is actually listening there.
+- **Routing/labels look wrong** — check `docker compose config` output for
+  the resolved label values, and check the Traefik dashboard/logs for the
+  `spread-your-sheets` router and `spread-your-sheets-web` service.
+- **Old version still showing after deploy** — likely a stale browser cache;
+  `index.html` is served with `Cache-Control: no-cache` specifically to avoid
+  this, so a hard refresh should be enough. Hashed files under `/assets/`
+  are cached long-term by design and change name on every build.
+
+## Local verification
+
+Build and smoke-test the image locally before relying on it in production:
+
+```bash
+# from repo root
+docker build -f deploy/Dockerfile.prod -t spread-your-sheets-web:local .
+docker run --rm -p 8080:80 spread-your-sheets-web:local
+
+curl http://localhost:8080/health
+# open http://localhost:8080 in a browser
+```


### PR DESCRIPTION
This pull request introduces a complete, production-ready self-hosted deployment workflow for the Spread Your Sheets app, transitioning from a planned deployment to a fully implemented, documented, and automated Docker/nginx-based solution. It adds all necessary Docker, nginx, and Compose artifacts, sets up a CI workflow for building and publishing images to GHCR, and updates documentation to reflect the new deployment process. Ownership and contact information in repo metadata are also updated.

**Deployment automation and artifacts:**

* Adds `deploy/Dockerfile.prod` for multi-stage Node/nginx builds, producing a minimal static image for the frontend app.
* Adds `deploy/nginx/default.conf` for secure, cache-optimized nginx serving with SPA routing and a `/health` endpoint.
* Adds `deploy/slightly-server/docker-compose.yml` and `.env.example` for running the app behind Traefik on slightly-server, using GHCR images and environment-based configuration. [[1]](diffhunk://#diff-210ddd5eacea40aac8b351635fa4824f316a43c98185eeb936521e3650dcee52R1-R20) [[2]](diffhunk://#diff-c41b37c3dffbf32d39e630128c765d72f0b5a169380bf15b009932301c784fb0R1-R10)
* Adds `.dockerignore` to keep image builds clean and efficient.
* Adds `.github/workflows/docker-build.yml` to automate lint/test/build and publish Docker images on every push to `main`.

**Documentation updates:**

* Adds `docs/deployment/self-hosted.md` with step-by-step setup, update, health check, and rollback instructions for the new deployment stack.
* Updates `README.md`, `PRD.md`, `CHECKLIST.md`, and `docs/architecture.md` to reflect the implemented deployment, replacing references to planned artifacts and describing the new image, Compose, and Traefik setup. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L158-R160) [[2]](diffhunk://#diff-f3f7b39d67748ec7d5da458a1bb1f98cf05f47d4e121c582f090e23280afd8f1L136-R136) [[3]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L256-R261) [[4]](diffhunk://#diff-f8ac50821be8c450509fc9a21bc266dd6d3093d2293d6e7b89cc799a62160c00L127-R127)

**Repo metadata and maintenance:**

* Updates code of conduct contact and Dependabot reviewer/assignee to `slightlyprivate`. [[1]](diffhunk://#diff-ffdbe3a1e7ee93cacfc080b6c635ccf3a8f6b0f00f2fb884f78c6b5f9dac8fd2L63-R63) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L13-R15) [[3]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L48-R50)

**Summary of most important changes:**

Deployment system and automation:
- Adds Dockerfile (`deploy/Dockerfile.prod`), nginx config (`deploy/nginx/default.conf`), Compose stack (`deploy/slightly-server/docker-compose.yml`, `.env.example`), and `.dockerignore` for a secure, minimal, production-ready deployment. [[1]](diffhunk://#diff-e7ce8fd19609a21aa546975793494ebbade8e6cd022075d792800ac71b357d4eR1-R20) [[2]](diffhunk://#diff-e76f5e5c1d29602fa3bb1a0a1195e35b8fbaf94c9d445a0a0e691cc77ea5582fR1-R37) [[3]](diffhunk://#diff-210ddd5eacea40aac8b351635fa4824f316a43c98185eeb936521e3650dcee52R1-R20) [[4]](diffhunk://#diff-c41b37c3dffbf32d39e630128c765d72f0b5a169380bf15b009932301c784fb0R1-R10) [[5]](diffhunk://#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5R1-R18)
- Implements GitHub Actions workflow (`.github/workflows/docker-build.yml`) for CI build, test, and automated Docker image publishing to GHCR.

Documentation:
- Adds and updates documentation to describe the new self-hosted deployment process, including setup, update, health check, and rollback. [[1]](diffhunk://#diff-7322865b68ef8a5a06987e90ac0e74a4fdf0c6ce88305ff52ae26d0af2e4cd83R1-R170) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L158-R160) [[3]](diffhunk://#diff-f3f7b39d67748ec7d5da458a1bb1f98cf05f47d4e121c582f090e23280afd8f1L136-R136) [[4]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L256-R261) [[5]](diffhunk://#diff-f8ac50821be8c450509fc9a21bc266dd6d3093d2293d6e7b89cc799a62160c00L127-R127)

Repo maintenance:
- Updates code of conduct contact and Dependabot reviewer/assignee to the new maintainer. [[1]](diffhunk://#diff-ffdbe3a1e7ee93cacfc080b6c635ccf3a8f6b0f00f2fb884f78c6b5f9dac8fd2L63-R63) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L13-R15) [[3]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L48-R50)