### PR TITLE
chore: ignore eslint and lint-staged major bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,6 +47,14 @@ updates:
       # vite's major line until vite itself is upgraded.
       - dependency-name: "@vitejs/plugin-react"
         update-types: ["version-update:semver-major"]
+      # eslint-plugin-react's latest release (7.37.5) caps its peer dep at
+      # eslint ^9.7; ESLint 10 isn't installable until that plugin catches up.
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
+      # lint-staged 17 requires Node >=22.22.1; this repo runs Node 20 in CI
+      # and locally. Revisit once the project's Node baseline moves to 22+.
+      - dependency-name: "lint-staged"
+        update-types: ["version-update:semver-major"]
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary
- Closed #103 (lint-staged 16→17) and #104 (eslint 9→10) as currently unmergeable:
  - ESLint 10: `eslint-plugin-react@7.37.5` (latest published) peer-deps on `eslint ^9.7` max — no compatible release exists yet.
  - lint-staged 17: requires Node `>=22.22.1`; this repo runs Node 20 in CI and locally.
- Adds both to the dependabot major-version ignore list (same pattern as `vite`/`@vitejs/plugin-react`) so they stop reopening every month until the underlying blockers clear.

## Test plan
- [x] YAML validated (`yaml.safe_load`)
- N/A — config-only change, no app code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)